### PR TITLE
Upgrade to 0.9.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openmmdl" %}
-{% set version = "0.9.2" %}
+{% set version = "0.9.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -22,23 +22,23 @@ requirements:
     - versioningit
   run:
     - python >=3.10
-    - numpy =1.26.4
-    - plip =2.3.0
+    - numpy
+    - plip
     - requests >=2.28.1
     - rdkit >=2022.03.5
-    - mdtraj =1.9.7
-    - pdbfixer =1.8.1
-    - openff-toolkit =0.16.0
-    - openmmforcefields =0.11.2
+    - mdtraj
+    - pdbfixer
+    - openff-toolkit
+    - openmmforcefields
     - cudatoolkit >=11.7.0
     - cuda-python >=11.7.1
     - mdanalysis >=2.3.0
     - pytest-shutil >=1.7.0
     - flask >=2.2.2
-    - cairosvg =2.7.1
-    - nglview =3.0.6
+    - cairosvg
+    - nglview
     - jupyter
-    - ambertools =22.0
+    - ambertools
     - numba >=0.59.1
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/wolberlab/OpenMMDL/archive/refs/tags/{{ version }}.zip
-  sha256: 2504461bed6915d92fa893520a3c9a24c2a1f269112914ffe1d686f5f71a85aa
+  sha256: 3e4dcf0b7977520ebd77c141d2200a040c3a3a799cdeba4984fe072dcac0599e
 
 build:
   noarch: python


### PR DESCRIPTION
Changes made:
Adjustment of following packages:

- version upgraded to `0.9.2.1`
- `numpy =1.26.4` --> `numpy`
- `plip =2.3.0` --> `plip`
- `mdtraj =1.9.7` --> `mdtraj`
- `pdbfixer =1.8.1` --> `pdbfixer`
- `openff-toolkit =0.16.0` --> `openff-toolkit`
- `openmmforcefields =0.11.2` --> `openmmforcefields`
- `cairosvg =2.7.1` --> `cairosvg`
- `nglview =3.0.6` --> `nglview`
- `ambertools =22.0` --> `ambertools`

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
